### PR TITLE
Fix sceRegMgrSetStr size argument

### DIFF
--- a/offact.c
+++ b/offact.c
@@ -85,7 +85,11 @@ int OffAct_SetAccountType(int account_numb, char val[ACCOUNT_TYPE_MAX])
 {
     int n = OffAct_GetEntityNumber(account_numb, 16U, 65536U, 125874183U,
 				   127184903U);
-    return sceRegMgrSetStr(n, val, ACCOUNT_TYPE_MAX);
+    size_t s = 0;
+    do {
+        s++;
+    } while (val[s - 1]);
+    return sceRegMgrSetStr(n, val, s);
 }
 
 


### PR DESCRIPTION
Please be careful before before merging because i haven't tested the change; but like this the code seems more correct: the third argument of sceRegMgrSetStr should be the size of the set string including the null terminator (instead of always being the maximum possible size as it is now).